### PR TITLE
fix: Remove unused imports to resolve ESLint errors

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,7 +7,8 @@ import StudyPlanDisplay, { StudyTask } from '@/features/planner/components/Study
 import ProgressChart, { ProgressData } from '@/features/planner/components/ProgressChart';
 import OverallProgress from '@/features/motivation/components/OverallProgress'; // Import new component
 import { Button } from '@/components/ui/button';
-import { LayoutDashboard, Target, ListChecks, BarChart2, PieChart as PieChartIcon, Activity, Trophy, Users } from 'lucide-react';
+// Removed Activity, Trophy, Users as they are unused for now
+import { LayoutDashboard, Target, ListChecks, BarChart2, PieChart as PieChartIcon } from 'lucide-react';
 
 // Mock data generation functions (ensure these are correctly defined as in previous versions)
 const generateMockStudyPlan = (goal: Goal): StudyTask[] => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 // src/app/layout.tsx
 'use client'; // Required for useState
 
-import type { Metadata } from "next"; // Keep for static metadata if parts are still static
+// import type { Metadata } from "next"; // Removed as metadata object is also removed
 import { Inter } from "next/font/google";
 import "./globals.css"; // Tailwind base, etc.
 import Header from "@/components/shared/Header";


### PR DESCRIPTION
- Removed unused icon imports (Activity, Trophy, Users) from `src/app/dashboard/page.tsx`.
- Removed unused Metadata type import from `src/app/layout.tsx`.

These changes address the ESLint errors that caused the build to fail.