### PR TITLE
fix: Remove Radix UI dependencies from dummy UI components

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,120 +1,117 @@
-// src/components/ui/dialog.tsx
+// src/components/ui/dialog.tsx (Simplified to remove Radix UI dependency for build)
 "use client"
 
 import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
-
 import { cn } from "@/lib/utils"
 
-const Dialog = DialogPrimitive.Root
-const DialogTrigger = DialogPrimitive.Trigger
-const DialogPortal = DialogPrimitive.Portal
-const DialogClose = DialogPrimitive.Close
+// Dummy Dialog component
+const Dialog = ({ open, onOpenChange, children }: { open?: boolean; onOpenChange?: (open: boolean) => void; children: React.ReactNode }) => {
+  if (!open) return null;
+  // This is a very basic representation. Real dialogs are much more complex.
+  // The onOpenChange is not directly used here but kept for API compatibility with how ProfilePage uses it.
+  return (
+    <div className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm flex items-center justify-center" onClick={() => onOpenChange?.(false)}>
+        {/* This is a placeholder for DialogPortal and DialogOverlay functionality */}
+        {children}
+    </div>
+  );
+};
+Dialog.displayName = "Dialog"
 
-const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      "fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
-    )}
-    {...props}
-  />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
+// Dummy DialogContent component
 const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & {onEscapeKeyDown?: () => void; onPointerDownOutside?: () => void;} // Added Radix-like props for compatibility
 >(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
-
-const DialogHeader = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+    // Stop propagation to prevent Dialog click-outside-to-close from triggering immediately
   <div
-    className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
-      className
-    )}
+    ref={ref}
+    className={cn("fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg", className)}
+    onClick={(e) => e.stopPropagation()} // Prevent click from closing the dialog via the overlay's onClick
     {...props}
-  />
-)
+    >
+    {children}
+    {/*
+      A real DialogClose would typically be a button.
+      For now, the ProfilePage's DialogClose uses its own Button.
+      We can add a visual X button here if needed, but it won't be Radix's DialogPrimitive.Close
+    */}
+  </div>
+));
+DialogContent.displayName = "DialogContent"
+
+
+// Dummy DialogHeader component
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+);
 DialogHeader.displayName = "DialogHeader"
 
-const DialogFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
+// Dummy DialogFooter component
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+);
 DialogFooter.displayName = "DialogFooter"
 
+// Dummy DialogTitle component
 const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+  HTMLHeadingElement, // Changed from ElementRef of DialogPrimitive.Title
+  React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
-    )}
-    {...props}
-  />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+  <h2 ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
+));
+DialogTitle.displayName = "DialogTitle"
 
+// Dummy DialogDescription component
 const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+  HTMLParagraphElement, // Changed from ElementRef of DialogPrimitive.Description
+  React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+  <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+DialogDescription.displayName = "DialogDescription"
+
+// Dummy DialogClose (not a button, but for API compatibility if used as <DialogClose asChild>)
+const DialogClose = React.forwardRef<
+    HTMLButtonElement, // Assuming it might be used with a button
+    React.ButtonHTMLAttributes<HTMLButtonElement> & {asChild?:boolean}
+>(({children, ...props}, ref) => {
+    if (props.asChild && React.isValidElement(children)) {
+        return React.cloneElement(children, {
+            // Attempt to find onClick and chain it with onOpenChange if Dialog's onOpenChange is available
+            // This is a very rough approximation.
+            ...children.props,
+        } as React.Attributes);
+    }
+  // This won't render a functional close button on its own without onOpenChange from Dialog.
+  // The ProfilePage implements its own close button.
+  return <button ref={ref} {...props}>{children || "Close"}</button>;
+});
+DialogClose.displayName = "DialogClose";
+
+
+// These are not used by the simplified Dialog, but exported for API compatibility
+const DialogTrigger = ({ children }: { children: React.ReactNode }) => <>{children}</>; // Dummy
+DialogTrigger.displayName = "DialogTrigger"
+
+const DialogPortal = ({ children }: { children: React.ReactNode }) => <>{children}</>; // Dummy
+DialogPortal.displayName = "DialogPortal"
+
+const DialogOverlay = ({ className }: { className?:string }) => <div className={cn("fixed inset-0 z-40 bg-black/50", className)} />; // Dummy overlay
+DialogOverlay.displayName = "DialogOverlay"
+
 
 export {
   Dialog,
-  DialogTrigger,
+  DialogTrigger, // Kept for API compatibility
   DialogContent,
   DialogHeader,
   DialogFooter,
   DialogTitle,
   DialogDescription,
-  DialogClose, // Added DialogClose to exports
-  DialogPortal, // Added DialogPortal to exports
-  DialogOverlay, // Added DialogOverlay to exports
+  DialogClose, // Kept for API compatibility
+  DialogPortal, // Kept for API compatibility
+  DialogOverlay, // Kept for API compatibility
 }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,27 +1,22 @@
-// src/components/ui/label.tsx
+// src/components/ui/label.tsx (Simplified to remove Radix UI dependency for build)
 "use client"
 
 import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
-
 import { cn } from "@/lib/utils"
 
-const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
-
 const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
+  HTMLLabelElement, // Changed from ElementRef of LabelPrimitive.Root
+  React.LabelHTMLAttributes<HTMLLabelElement> // Changed from ComponentPropsWithoutRef of LabelPrimitive.Root
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
+  <label
     ref={ref}
-    className={cn(labelVariants(), className)}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70", // Basic styling from shadcn
+      className
+    )}
     {...props}
   />
 ))
-Label.displayName = LabelPrimitive.Root.displayName
+Label.displayName = "Label"
 
 export { Label }


### PR DESCRIPTION
- Modified `src/components/ui/dialog.tsx` to be a basic div structure, removing the dependency on `@radix-ui/react-dialog`.
- Modified `src/components/ui/label.tsx` to be a basic HTML label element, removing the dependency on `@radix-ui/react-label`.

These changes are temporary workarounds to resolve build errors caused by missing Radix UI primitive libraries. The proper solution is to install these dependencies in the development environment. The functionality of these components will be significantly limited.