### PR TITLE
fix: Remove unused parameter from GET handler in feed API

### DIFF
--- a/src/app/api/sns/feed/route.ts
+++ b/src/app/api/sns/feed/route.ts
@@ -61,7 +61,7 @@ const currentUserMock: Pick<UserProfile, 'userId' | 'username' | 'avatarUrl' | '
 };
 
 
-export async function GET(_request: Request) { // Changed request to _request
+export async function GET() { // Removed _request: Request as it's unused
   // In a real app, you might have pagination, filtering, etc.
   // For now, just return all mock posts sorted by newest first.
   const sortedPosts = [...mockFeedPosts].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());


### PR DESCRIPTION
- Removed the unused `_request` parameter from the GET handler in `src/app/api/sns/feed/route.ts` to resolve ESLint error.