### PR TITLE
fix: Correct type signature for dynamic route handlers

### DIFF
--- a/src/app/api/sns/profile/[userId]/route.ts
+++ b/src/app/api/sns/profile/[userId]/route.ts
@@ -30,10 +30,10 @@ const mockUserProfiles: Record<string, UserProfile> = {
 };
 
 export async function GET(
-  request: Request,
-  { params }: { params: { userId: string } }
+  _request: Request, // Marked as unused
+  context: { params: { userId: string } }
 ) {
-  const userId = params.userId;
+  const userId = context.params.userId;
 
   if (mockUserProfiles[userId]) {
     return NextResponse.json(mockUserProfiles[userId]);
@@ -50,9 +50,9 @@ export async function GET(
 
 export async function PUT(
   request: Request,
-  { params }: { params: { userId: string } }
+  context: { params: { userId: string } }
 ) {
-  const userId = params.userId;
+  const userId = context.params.userId;
   const data = await request.json();
 
   // Simulate updating the current user's profile (e.g., 'user123')


### PR DESCRIPTION
- Modified the second argument of GET and PUT handlers in `src/app/api/sns/profile/[userId]/route.ts` to correctly type the context object containing params.
- Marked the `request` parameter as unused in the GET handler.

This resolves the TypeScript error regarding invalid export types for route handlers.